### PR TITLE
Fixing the bug in the OOV projection

### DIFF
--- a/src/bilind.py
+++ b/src/bilind.py
@@ -281,7 +281,7 @@ class bilingual_mapping():
         # Get the IIVs
         if any_oov and iov_mode == 'projection' and oov_mode == 'projection':
             # Both are projected
-            xt_hat = np.concatenate([self.xt,self.xt_oov])@self.mapping
+            xt_hat = np.concatenate([self.xt,self.xt_oov])@self.mapping.T
         else:
             # Will treat IIV and OOVs differently
             if iov_mode == 'barycentric':


### PR DESCRIPTION
There was a small but important bug in projecting OOVs with the learned mapping. 
This bug is triggered after executing the method `BLI.load_oov_data`.

(It's hard to notice since the mapping is a square matrix.)

TEST: Tested the exported embedding with the suffix "*proj-proj.txt" using  [evaluate.py](https://github.com/facebookresearch/MUSE/blob/master/evaluate.py) from the MUSE project. 